### PR TITLE
Update setup.py to include the HTML template files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     author_email='bruno@renie.fr',
     packages=find_packages(),
     include_package_data=True,
+    package_data = {'password_reset': ['templates/password_reset/*.html',]},
     url='https://github.com/brutasse/django-password-reset',
     license='BSD licence, see LICENSE file',
     description='Class-based views for password reset.',


### PR DESCRIPTION
The template files currently aren't included when installing this package with pip.

I haven't tested it, but the fix is simple enough and should work ;-)
