### PR TITLE
HTML template added for the recovery email

### DIFF
--- a/docs/views.rst
+++ b/docs/views.rst
@@ -43,6 +43,10 @@ Attributes
 * ``email_template_name``: the template to use for sending the reset link by
   email. Default: ``password_reset/recovery_email.txt``.
 
+* ``email_html_template_name``: the HTML template to use for sending the reset link by
+  email. The content of this template will be sent as the text/html content type alternative.
+  Default: ``password_reset/recovery_email.html``.
+
 * ``email_subject_template_name``: the template to use for generating the
   email subject. Defaults to ``password_reset/recovery_email_subject.txt``.
 

--- a/password_reset/templates/password_reset/base_email.html
+++ b/password_reset/templates/password_reset/base_email.html
@@ -1,0 +1,184 @@
+{% load i18n %}
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"> 
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+	<title>{% block title %}{% endblock title %}</title>
+	<style type="text/css">
+		/* Based on The MailChimp Reset INLINE: Yes. */  
+		/* Client-specific Styles */
+		#outlook a {padding:0;} /* Force Outlook to provide a "view in browser" menu link. */
+		body{width:100% !important; -webkit-text-size-adjust:100%; -ms-text-size-adjust:100%; margin:0; padding:0;} 
+		/* Prevent Webkit and Windows Mobile platforms from changing default font sizes.*/ 
+		.ExternalClass {width:100%;} /* Force Hotmail to display emails at full width */  
+		.ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td, .ExternalClass div {line-height: 100%;}
+		/* Forces Hotmail to display normal line spacing.  More on that: http://www.emailonacid.com/forum/viewthread/43/ */ 
+		#idbackground_table {margin:0; padding:0; width:100% !important; line-height: 100% !important; background-color: #CECECE;}
+		/* End reset */
+
+		/* Some sensible defaults for images
+		Bring inline: Yes. */
+		img {outline:none; text-decoration:none; -ms-interpolation-mode: bicubic;} 
+		a img {border:none;} 
+		.image_fix {display:block;}
+
+		/* Yahoo paragraph fix
+		Bring inline: Yes. */
+		p {margin: 1em 0;}
+
+		/* Hotmail header color reset
+		Bring inline: Yes. */
+		h1, h2, h3, h4, h5, h6 {color: black !important;}
+
+		h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {color: blue !important;}
+
+		h1 a:active, h2 a:active,  h3 a:active, h4 a:active, h5 a:active, h6 a:active {
+		color: red !important; /* Preferably not the same color as the normal header link color.  There is limited support for psuedo classes in email clients, this was added just for good measure. */
+		}
+
+		h1 a:visited, h2 a:visited,  h3 a:visited, h4 a:visited, h5 a:visited, h6 a:visited {
+		color: purple !important; /* Preferably not the same color as the normal header link color. There is limited support for psuedo classes in email clients, this was added just for good measure. */
+		}
+
+		/* Outlook 07, 10 Padding issue fix
+		Bring inline: No.*/
+		table td {border-collapse: collapse;}
+
+        /* Remove spacing around Outlook 07, 10 tables
+        Bring inline: Yes */
+        table { border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt; }
+
+		/* Styling your links has become much simpler with the new Yahoo.  In fact, it falls in line with the main credo of styling in email and make sure to bring your styles inline.  Your link colors will be uniform across clients when brought inline.
+		Bring inline: Yes. */
+		a {color: orange;}
+
+
+		/***************************************************
+		****************************************************
+		MOBILE TARGETING
+		****************************************************
+		***************************************************/
+        #id_page {
+            margin: 20px auto;
+            background-color: #ffffff;
+            font-family: Lucida, Helvetica, Arial, sans-serif;
+            font-size: 12px;
+        }
+        
+        #id_logo {
+            display: block;
+            margin: 0px auto;
+        }
+        
+        #id_footer {
+            background-color: #77B5FE;
+        }
+        
+        #id_footer a {
+            text-decoration: none;
+            color: #ffffff;
+            margin-right: 20px;
+        }
+        
+		@media only screen and (max-device-width: 480px) {
+			/* Part one of controlling phone number linking for mobile. */
+			a[href^="tel"], a[href^="sms"] {
+						text-decoration: none;
+						color: blue; /* or whatever your want */
+						pointer-events: none;
+						cursor: default;
+					}
+
+			.mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+						text-decoration: default;
+						color: orange !important;
+						pointer-events: auto;
+						cursor: default;
+					}
+		}
+		
+		{% comment %}
+		/* More Specific Targeting */
+		@media only screen and (min-device-width: 768px) and (max-device-width: 1024px) {
+		/* You guessed it, ipad (tablets, smaller screens, etc) */
+			/* repeating for the ipad */
+			a[href^="tel"], a[href^="sms"] {
+						text-decoration: none;
+						color: blue; /* or whatever your want */
+						pointer-events: none;
+						cursor: default;
+					}
+
+			.mobile_link a[href^="tel"], .mobile_link a[href^="sms"] {
+						text-decoration: default;
+						color: orange !important;
+						pointer-events: auto;
+						cursor: default;
+					}
+		}
+
+		@media only screen and (-webkit-min-device-pixel-ratio: 2) {
+		/* Put your iPhone 4g styles in here */ 
+		}
+
+		/* Android targeting */
+		@media only screen and (-webkit-device-pixel-ratio:.75){
+		/* Put CSS for low density (ldpi) Android layouts in here */
+		}
+		@media only screen and (-webkit-device-pixel-ratio:1){
+		/* Put CSS for medium density (mdpi) Android layouts in here */
+		}
+		@media only screen and (-webkit-device-pixel-ratio:1.5){
+		/* Put CSS for high density (hdpi) Android layouts in here */
+		}
+		/* end Android targeting */
+		{% endcomment %}
+	</style>
+
+	<!-- Targeting Windows Mobile -->
+	<!--[if IEMobile 7]>
+	<style type="text/css">
+	
+	</style>
+	<![endif]-->   
+
+	<!-- ***********************************************
+	****************************************************
+	END MOBILE TARGETING
+	****************************************************
+	************************************************ -->
+
+	<!--[if gte mso 9]>
+		<style>
+		/* Target Outlook 2007 and 2010 */
+		</style>
+	<![endif]-->
+</head>
+<body bgcolor="#CECECE">
+<!-- Wrapper/Container Table: Use a wrapper table to control the width and the background color consistently of your email. Use this approach instead of setting attributes on the body tag. -->
+<table cellpadding="0" cellspacing="0" border="0" id="id_background_table" width="100%">
+	<tr>
+		<td valign="top">
+		    <table id="id_page" border="0" cellspacing="5" cellpadding="10" width="640">
+                <tr>
+                    <td></td>
+                </tr>
+                <tr>
+                    <td style="padding: 0 30px">
+                        {% block content %}
+                        {% endblock content %}
+                    </td>
+                </tr>
+                <tr id="id_footer">
+                    <td>
+                        <a href="http://{{ site.domain }}">{% blocktrans with site_name=site.name %}Go to {{ site_name }}{% endblocktrans %}</a>
+                    </td>
+                </tr>
+            </table> 
+		</td>
+	</tr>
+</table>  
+<!-- End of wrapper table -->
+</body>
+</html>

--- a/password_reset/templates/password_reset/base_email.html
+++ b/password_reset/templates/password_reset/base_email.html
@@ -172,7 +172,7 @@
                 </tr>
                 <tr id="id_footer">
                     <td>
-                        <a href="http://{{ site.domain }}">{% blocktrans with site_name=site.name %}Go to {{ site_name }}{% endblocktrans %}</a>
+                        <a href="http{% if secure %}s{% endif %}{{ site.domain }}">{% blocktrans with site_name=site.name %}Go to {{ site_name }}{% endblocktrans %}</a>
                     </td>
                 </tr>
             </table> 

--- a/password_reset/templates/password_reset/recovery_email.html
+++ b/password_reset/templates/password_reset/recovery_email.html
@@ -1,0 +1,10 @@
+{% extends "password_reset/base_email.html" %}
+{% load i18n %}
+{% load url from future %}
+
+{% block content %}
+	<p>{% blocktrans %}Dear {{ username }},{% endblocktrans %}</p>
+	<p>{% blocktrans with domain=site.domain %}You -- or someone pretending to be you -- has requested a password reset on {{ domain }}.{% endblocktrans %}</p>
+	<p>{% trans "You can set your new password by following this link:" %}&nbsp;<a href="http{% if secure %}s{% endif %}://{{ site.domain }}{% url "password_reset_reset" token %}">http{% if secure %}s{% endif %}://{{ site.domain }}{% url "password_reset_reset" token %}</a></p>
+	<p>{% trans "If you don't want to reset your password, simply ignore this email and it will stay unchanged." %}</p>
+{% endblock content %}

--- a/password_reset/tests/tests.py
+++ b/password_reset/tests/tests.py
@@ -275,6 +275,8 @@ class ViewTests(TestCase):
             url, {'username_or_email': 'bar@example.com'}, follow=True,
         )
         self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(len(mail.outbox[0].alternatives), 1)
+        self.assertEqual(mail.outbox[0].alternatives[0][1], 'text/html')
         self.assertEqual(len(response.redirect_chain), 1)
         self.assertContains(response, 'bar@example.com')
 

--- a/password_reset/views.py
+++ b/password_reset/views.py
@@ -3,7 +3,7 @@ import datetime
 from django.conf import settings
 from django.contrib.sites.models import Site, RequestSite
 from django.core import signing
-from django.core.mail import send_mail
+from django.core.mail import EmailMultiAlternatives
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.shortcuts import get_object_or_404, redirect
 from django.http import Http404
@@ -53,6 +53,7 @@ class Recover(SaltMixin, generic.FormView):
     template_name = 'password_reset/recovery_form.html'
     success_url_name = 'password_reset_sent'
     email_template_name = 'password_reset/recovery_email.txt'
+    email_html_template_name = 'password_reset/recovery_email.html'
     email_subject_template_name = 'password_reset/recovery_email_subject.txt'
     search_fields = ['username', 'email']
 
@@ -85,12 +86,14 @@ class Recover(SaltMixin, generic.FormView):
             'token': signing.dumps(self.user.pk, salt=self.salt),
             'secure': self.request.is_secure(),
         }
-        body = loader.render_to_string(self.email_template_name,
-                                       context).strip()
-        subject = loader.render_to_string(self.email_subject_template_name,
-                                          context).strip()
-        send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
-                  [self.user.email])
+        text_content = loader.render_to_string(self.email_template_name, context).strip()
+        html_content = loader.render_to_string(self.email_html_template_name, context).strip()
+        subject = loader.render_to_string(self.email_subject_template_name, context).strip()
+
+        msg = EmailMultiAlternatives(subject, text_content, settings.DEFAULT_FROM_EMAIL, [self.user.email, ])
+        msg.attach_alternative(html_content, 'text/html')
+
+        msg.send()
 
     def form_valid(self, form):
         self.user = form.cleaned_data['user']

--- a/password_reset/views.py
+++ b/password_reset/views.py
@@ -86,11 +86,16 @@ class Recover(SaltMixin, generic.FormView):
             'token': signing.dumps(self.user.pk, salt=self.salt),
             'secure': self.request.is_secure(),
         }
-        text_content = loader.render_to_string(self.email_template_name, context).strip()
-        html_content = loader.render_to_string(self.email_html_template_name, context).strip()
-        subject = loader.render_to_string(self.email_subject_template_name, context).strip()
+        text_content = loader.render_to_string(
+            self.email_template_name, context).strip()
+        html_content = loader.render_to_string(
+            self.email_html_template_name, context).strip()
+        subject = loader.render_to_string(
+            self.email_subject_template_name, context).strip()
 
-        msg = EmailMultiAlternatives(subject, text_content, settings.DEFAULT_FROM_EMAIL, [self.user.email, ])
+        msg = EmailMultiAlternatives(
+            subject, text_content,
+            settings.DEFAULT_FROM_EMAIL, [self.user.email, ])
         msg.attach_alternative(html_content, 'text/html')
 
         msg.send()


### PR DESCRIPTION
It should be possible to send both text and HTML versions of the recovery email. Here is a proposal to handle this case.
