### PR TITLE
read token expire date from settings

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -30,7 +30,7 @@ What you get
 
 * The ability to look for your user's username or email address.
 
-* Password reset links that expire in two days (configurable).
+* Password reset links that expire in two days (configurable via PASSWORD_RESET_TOKEN_EXPIRES in your settings).
 
 What you can do
 ---------------

--- a/password_reset/views.py
+++ b/password_reset/views.py
@@ -111,7 +111,7 @@ recover = Recover.as_view()
 
 class Reset(SaltMixin, generic.FormView):
     form_class = PasswordResetForm
-    token_expires = 3600 * 48  # Two days
+    token_expires = getattr(settings, 'PASSWORD_RESET_TOKEN_EXPIRES', 3600 * 48)
     template_name = 'password_reset/reset.html'
     success_url = reverse_lazy('password_reset_done')
 


### PR DESCRIPTION
Default token expire period is still two days, while this commit let user change this behavior in settings by changing value of PASSWORD_RESET_TOKEN_EXPIRES in seconds.