### PR TITLE
Updates for Python 3.5 and Django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: "3.4"
+python: "3.5"
 sudo: false
 cache: pip
 env:
@@ -9,6 +9,7 @@ env:
   - TOXENV=py27-django16
   - TOXENV=py27-django17
   - TOXENV=py27-django18
+  - TOXENV=py27-django19
   - TOXENV=py33-django15
   - TOXENV=py33-django16
   - TOXENV=py33-django17
@@ -17,6 +18,9 @@ env:
   - TOXENV=py34-django16
   - TOXENV=py34-django17
   - TOXENV=py34-django18
+  - TOXENV=py34-django19
+  - TOXENV=py35-django18
+  - TOXENV=py35-django19
   - TOXENV=docs
   - TOXENV=lint
 install:

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -57,10 +57,10 @@ Methods
 * ``send_notification()``: this builds the email context, loads the template
   and sends the password reset email.
 
-* ``get_site()``: method to obtain the website's host name.  This method first 
-  checks and sets the site from the optional `Django sites framework
-  <https://docs.djangoproject.com/en/dev/ref/contrib/sites/>`_.  If missing,
-  it will deduce the domain and name by looking at the request object's domain.
+* ``get_site()``: method to obtain the website's host name.  This method is
+  simply a wrapper around Django's `get_current_site`_.
+
+  .. _get_current_site: https://docs.djangoproject.com/en/stable/ref/contrib/sites/#get-current-site-shortcut
 
 RecoverDone
 -----------

--- a/password_reset/tests/tests.py
+++ b/password_reset/tests/tests.py
@@ -6,7 +6,10 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import timezone
 from django.utils.six import with_metaclass
-from django.utils.unittest import SkipTest
+try:
+    from django.utils.unittest import SkipTest
+except ImportError:
+    from unittest import SkipTest
 
 from ..forms import PasswordRecoveryForm, PasswordResetForm
 from ..utils import get_user_model

--- a/password_reset/views.py
+++ b/password_reset/views.py
@@ -1,7 +1,6 @@
 import datetime
 
 from django.conf import settings
-from django.contrib.sites.models import Site
 from django.core import signing
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse, reverse_lazy
@@ -14,9 +13,9 @@ from django.views import generic
 from django.views.decorators.debug import sensitive_post_parameters
 
 try:
-    from django.contrib.sites.requests import RequestSite
+    from django.contrib.sites.shortcuts import get_current_site
 except ImportError:
-    from django.contrib.sites.models import RequestSite
+    from django.contrib.sites.models import get_current_site
 
 from .forms import PasswordRecoveryForm, PasswordResetForm
 from .signals import user_recovers_password
@@ -79,10 +78,7 @@ class Recover(SaltMixin, generic.FormView):
         return kwargs
 
     def get_site(self):
-        if Site._meta.installed:
-            return Site.objects.get_current()
-        else:
-            return RequestSite(self.request)
+        return get_current_site(self.request)
 
     def send_notification(self):
         context = {
@@ -127,6 +123,7 @@ class Reset(SaltMixin, generic.FormView):
         self.request = request
         self.args = args
         self.kwargs = kwargs
+        self.user = None
 
         try:
             pk = signing.loads(kwargs['token'], max_age=self.token_expires,

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,10 @@
 [tox]
 envlist =
     py26-django1{5,6},
-    py{27,33,34}-django1{5,6,7,8},
+    py27-django1{5,6,7,8,9},
+    py33-django1{5,6,7,8},
+    py34-django1{5,6,7,8,9},
+    py35-django1{8,9},
     docs, lint
 
 [testenv]
@@ -11,15 +14,17 @@ basepython =
     py27: python2.7
     py33: python3.3
     py34: python3.4
+    py35: python3.5
 deps =
     django-discover-runner
     django15: Django>=1.5,<1.6
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
 
 [testenv:docs]
-basepython = python3.4
+basepython = python3.5
 changedir = docs
 deps =
 	Sphinx
@@ -28,7 +33,7 @@ commands =
 	sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:lint]
-basepython = python3.4
+basepython = python3.5
 deps =
 	flake8
 commands =


### PR DESCRIPTION
Replace get_site with a call to Django's get_current_site.  Comparing
get_site with Django's get_current_site shows that their implementations
are identical (see [Django 1.4's version][1] or [Django 1.8's][2]).

Django 1.9 moved form initialization to get_context_data, and
get_context_data is called even if the Reset view returns invalid.  To
accommodate, I added code to initialize user in Reset.dispatch.

This fixes issue #36.

[1]: https://github.com/django/django/blob/stable/1.4.x/django/contrib/sites/models.py#L86
[2]: https://github.com/django/django/blob/stable/1.8.x/django/contrib/sites/shortcuts.py