### PR TITLE
Adding the ability to change case sensitivity with a django setting

### DIFF
--- a/password_reset/views.py
+++ b/password_reset/views.py
@@ -71,6 +71,10 @@ class Recover(SaltMixin, generic.FormView):
 
     def get_form_kwargs(self):
         kwargs = super(Recover, self).get_form_kwargs()
+
+        if hasattr(settings, 'PASSWORD_RESET_CASE_SENSITIVE'):
+            self.case_sensitive = settings.PASSWORD_RESET_CASE_SENSITIVE
+
         kwargs.update({
             'case_sensitive': self.case_sensitive,
             'search_fields': self.search_fields,


### PR DESCRIPTION
I didn't see a way to use the default settings module that's in django just to change whether or not this looks for case sensitivity, so I added a small bit of logic that checks to see if settings.PASSWORD_RESET_CASE_SENSITIVE is set. If it is, then the form listens to that setting to allow for quick case sensitivity updates to the default flow, without having to extend and override the "Recover" view.

If this functionality is already included and I've missed it, please let me know!