### PR TITLE
[REVIEW] allowed override from calling app

### DIFF
--- a/password_reset/__init__.py
+++ b/password_reset/__init__.py
@@ -1,1 +1,21 @@
+from django.conf import settings
+
+try:
+    from django.contrib.sites.shortcuts import get_current_site
+except ImportError:
+    from django.contrib.sites.models import get_current_site
+
 __version__ = '0.8.1'
+
+DEFAULT_SETTINGS = {
+		'token_expires': 3600 * 48,  # Two days
+		'get_current_site': get_current_site
+}
+
+PASSWORD_RESET_SETTINGS = getattr(settings,
+																	'PASSWORD_RESET_SETTINGS',
+																	DEFAULT_SETTINGS)
+
+
+DEFAULT_SETTINGS.update(PASSWORD_RESET_SETTINGS)
+print PASSWORD_RESET_SETTINGS

--- a/password_reset/__init__.py
+++ b/password_reset/__init__.py
@@ -12,10 +12,12 @@ DEFAULT_SETTINGS = {
 		'get_current_site': get_current_site
 }
 
-PASSWORD_RESET_SETTINGS = getattr(settings,
-																	'PASSWORD_RESET_SETTINGS',
-																	DEFAULT_SETTINGS)
-
+try:
+		PASSWORD_RESET_SETTINGS = getattr(settings,
+																			'PASSWORD_RESET_SETTINGS',
+																			DEFAULT_SETTINGS)
+except:
+		pass
 
 DEFAULT_SETTINGS.update(PASSWORD_RESET_SETTINGS)
 print PASSWORD_RESET_SETTINGS

--- a/password_reset/__init__.py
+++ b/password_reset/__init__.py
@@ -17,7 +17,7 @@ try:
 																			'PASSWORD_RESET_SETTINGS',
 																			DEFAULT_SETTINGS)
 except:
-		pass
+		PASSWORD_RESET_SETTINGS = {}
 
 DEFAULT_SETTINGS.update(PASSWORD_RESET_SETTINGS)
 print PASSWORD_RESET_SETTINGS

--- a/password_reset/views.py
+++ b/password_reset/views.py
@@ -12,10 +12,7 @@ from django.utils.decorators import method_decorator
 from django.views import generic
 from django.views.decorators.debug import sensitive_post_parameters
 
-try:
-    from django.contrib.sites.shortcuts import get_current_site
-except ImportError:
-    from django.contrib.sites.models import get_current_site
+from . import PASSWORD_RESET_SETTINGS
 
 from .forms import PasswordRecoveryForm, PasswordResetForm
 from .signals import user_recovers_password
@@ -78,7 +75,7 @@ class Recover(SaltMixin, generic.FormView):
         return kwargs
 
     def get_site(self):
-        return get_current_site(self.request)
+        return PASSWORD_RESET_SETTINGS['get_current_site'](self.request)
 
     def send_notification(self):
         context = {
@@ -114,7 +111,7 @@ recover = Recover.as_view()
 
 class Reset(SaltMixin, generic.FormView):
     form_class = PasswordResetForm
-    token_expires = 3600 * 48  # Two days
+    token_expires = PASSWORD_RESET_SETTINGS.get('token_expires', 3600 * 48)  # Two days
     template_name = 'password_reset/reset.html'
     success_url = reverse_lazy('password_reset_done')
 


### PR DESCRIPTION
currently a number of settings cant be overridden.

implemented a simple pattern for providing required settings.

**main requriement**

was to be able to override the get_current_site method call as not all sites use the django.contrib.sites package