### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Installation
 For extensive documentation see the ``docs`` folder or `read it on
 readthedocs`_
 
-.. _read it on readthedocs: http://django-password-reset.readthedocs.org/
+.. _read it on readthedocs: https://django-password-reset.readthedocs.io/
 
 To install the `in-development version`_ of django-password-reset, run ``pip
 install django-password-reset==dev``.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.