### PR TITLE
Django 2 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ functionality.
 
 * Author: Bruno Renié and `contributors`_
 * Licence: BSD
-* Compatibility: Django 1.8+
+* Compatibility: Django 1.10+
 
 .. _contributors: https://github.com/brutasse/django-password-reset/contributors
 

--- a/password_reset/tests/tests.py
+++ b/password_reset/tests/tests.py
@@ -2,9 +2,9 @@ from unittest import SkipTest
 
 from django.contrib.auth import get_user_model
 from django.core import mail
-from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.six import with_metaclass
 

--- a/password_reset/views.py
+++ b/password_reset/views.py
@@ -5,10 +5,10 @@ from django.contrib.auth import get_user_model
 from django.contrib.sites.shortcuts import get_current_site
 from django.core import signing
 from django.core.mail import send_mail
-from django.core.urlresolvers import reverse, reverse_lazy
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template import loader
+from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views import generic

--- a/setup.py
+++ b/setup.py
@@ -19,16 +19,15 @@ setup(
     description='Class-based views for password reset.',
     long_description=open('README.rst').read(),
     install_requires=[
-        'Django>=1.8',
+        'Django>=1.10',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py27-django1{8,9,10,11},
-    py33-django18,
-    py34-django1{8,9,10,11},
+    py27-django1{10,11},
+    py34-django1{10,11},
     py35-django1{8,9,10,11},
+    py35-django20,
     docs, lint
 
 [testenv]
@@ -14,10 +14,9 @@ basepython =
     py34: python3.4
     py35: python3.5
 deps =
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
+    django20: Django>=2.0,<2.1
 
 [testenv:docs]
 basepython = python3.5


### PR DESCRIPTION
Changes:
 * Fix location of moved `urls` moduule.
 * Update minimum requirements to Django 1.10 (which was the first version with support for the new location of the `urls` module).