### PR TITLE
Add documentation on customization

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -1,0 +1,20 @@
+Customization
+=============
+
+The preferred way to customize django-password-reset is by subclassing its
+views.  Configuration via Django's settings is not supported.  (After all, is
+the ``case_sensitive`` or ``token_expires`` parameter really going to change
+between local development, staging, and production?)
+
+Although subclassing is preferred, django-password-view settings are
+implemented as class attributes, so they can be overridden by setting views'
+class attributes in your application's startup code.  For example, you could
+enable case insensitive matching by adding the following code to your root
+``urls.py``.  Note that this behavior may change without warning in a future
+version of django-password-reset.
+
+::
+
+    import password_reset.views
+    password_reset.views.Recover.case_sensitive = False
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ Contents:
    quickstart
    views
    signals
+   customization
 
 Changelog
 ---------


### PR DESCRIPTION
I was hoping to be able to change settings just by setting something in
my Django settings (as described in #6).  Since django-password-settings
deliberately doesn't support that, I thought it would be helpful to add
some easy-to-follow instructions on how its options can be customized
(preferably without having to subclass).

Feedback welcome - if this doesn't fit your intended usage, or if you'd
prefer that things be expressed differently, or if you'd also like some
step-by-step instructions for subclassing, please let me know.