### PR TITLE
Update base.html

### DIFF
--- a/password_reset/templates/password_reset/base.html
+++ b/password_reset/templates/password_reset/base.html
@@ -1,1 +1,5 @@
-{% extends "base.html" %}
+{% block title %}
+{% endblock %}
+
+{% block content %}
+{% endblock %}


### PR DESCRIPTION
current password_reset/base.html is trying to extend 'base.html', which is not present in mast cases and hence it gives an error, so basically the whole thing doesn't work. Moreover nothing about this was mentioned the docs.