### PR TITLE
Add Django 4.2 support

### DIFF
--- a/password_reset/forms.py
+++ b/password_reset/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.contrib.auth import get_user_model
 from django.core.validators import validate_email
 from django.db.models import Q
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 
 

--- a/password_reset/signals.py
+++ b/password_reset/signals.py
@@ -1,6 +1,5 @@
 from django.dispatch import Signal
 
 # signal sent when users successfully recover their passwords
-user_recovers_password = Signal(
-    providing_args=['user', 'request']
-)
+# args=['user', 'request']
+user_recovers_password = Signal()

--- a/password_reset/urls.py
+++ b/password_reset/urls.py
@@ -1,13 +1,13 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 
 urlpatterns = [
-    url(r'^recover/(?P<signature>.+)/$', views.recover_done,
+    path('recover/<str:signature>/', views.recover_done,
         name='password_reset_sent'),
-    url(r'^recover/$', views.recover, name='password_reset_recover'),
-    url(r'^reset/done/$', views.reset_done, name='password_reset_done'),
-    url(r'^reset/(?P<token>[\w:-]+)/$', views.reset,
+    path('recover/', views.recover, name='password_reset_recover'),
+    path('reset/done/', views.reset_done, name='password_reset_done'),
+    path('reset/<str:token>/', views.reset,
         name='password_reset_reset'),
 ]


### PR DESCRIPTION
Based on https://github.com/karlwnw/django-password-reset/tree/feature/django4-compat ([PR 84](https://github.com/brutasse/django-password-reset/pull/84))

* use `gettext_lazy` instead of `ugettext_lazy`
* use `Signal()` without args
* use `path()` instead of `url()`